### PR TITLE
adding validate-account negative test cases

### DIFF
--- a/pact/shares.pact
+++ b/pact/shares.pact
@@ -109,13 +109,13 @@
 ; =========== ACCOUNT CONSTANTS =============================================== ; Account Constants                                                                                   ;
                                                                                 ;                                                                                                     ;
 (defconst SHARES_CHARSET CHARSET_LATIN1                                         ; Restricts account names to 'CHARSET_LATIN1' (ISO-8859-1) characters.                                ;
-  "The default coin contract character set")                                    ; Public Documentation "The default coin contract character set"                                      ;
+  "The default share contract character set")                                    ; Public Documentation "The default share contract character set"                                      ;
 (defconst MINIMUM_PRECISION:integer 12                                          ; Sets minimum share precision to 12 decimals                                                         ;
-  "Minimum allowed precision for coin transactions")                            ; Public Documentation "Minimum allowed precision for coin transactions"                              ;
+  "Minimum allowed precision for share transactions")                            ; Public Documentation "Minimum allowed precision for share transactions"                              ;
 (defconst MINIMUM_ACCOUNT_LENGTH:integer 3                                      ; Ensures account names are greart than 3 characters.                                                 ;
-  "Minimum account length admissible for coin accounts")                        ; Public Documentation "Minimum account length admissible for coin accounts"                          ;
+  "Minimum account length admissible for share accounts")                        ; Public Documentation "Minimum account length admissible for share accounts"                          ;
 (defconst MAXIMUM_ACCOUNT_LENGTH:integer 256                                    ; Limits account names to less than 256 characters.                                                   ;
-  "Maximum account name length admissible for coin accounts")                   ; Public Documentation "Maximum account name length admissible for coin accounts"                     ;
+  "Maximum account name length admissible for share accounts")                   ; Public Documentation "Maximum account name length admissible for share accounts"                     ;
                                                                                 ;                                                                                                     ;
 ; =========== ACCOUNT SCHEMAS ================================================= ; Details of Shares Accounts                                                                          ;
                                                                                 ;                                                                                                     ;
@@ -192,7 +192,7 @@
 @doc "Internal function to validate the Account name is in complience."         ; Public Documentation "Internal function to validate the Account name is in complience.".            ;
   (enforce                                                                      ; Enforces the following                                                                              ;
     (is-charset SHARES_CHARSET account)                                         ; The Account conforms to the supported characters.                                                   ;
-    (format "Account does not conform to the coin contract charset: {}"         ; Returns error message if false.                                                                     ;
+    (format "Account does not conform to the share contract charset: {}"         ; Returns error message if false.                                                                     ;
       [account]))                                                               ;                                                                                                     ;
   (let ((account-length (length account)))                                      ; Let "account-length" be the length of the Account.                                                  ;
     (enforce                                                                    ; Enforces the following                                                                              ;

--- a/pact/tests/smartpacts/shares-negative-testing.repl
+++ b/pact/tests/smartpacts/shares-negative-testing.repl
@@ -3,54 +3,122 @@
 (env-data {})
 (env-sigs [])
 
+; The function enforce-unit ensures the amount of shares is within MINIMUM_PRECISION policy. 
+; input must be decimal. 
+; output must be boolean.
+; input must be equal to it's self round down to 12 decimal digits. 
+
 (begin-tx "enforce-unit testing")
-; enforce-unit validates the following
-; input is decimal 
-; output is boolean
-; input decimal should be equal to it's round down version to 12 digits after decimal point 
-; note: Only validates precision of positive and negative decimal numbers.  
+
+(use smartpacts.shares)
+
 (expect
     "Returns true with 12 or less decimal digits"
     true
-    (smartpacts.shares.enforce-unit 1.123456789012))
+    (enforce-unit 1.123456789012))
+
 (expect
     "Returns true with 12 or less negative decimal digits"
     true
-    (smartpacts.shares.enforce-unit -1.12345678901))
+    (enforce-unit -1.12345678901))
+
 (expect-failure
     "Returns error with integer number"
     "Type error: expected decimal, found integer"
-    (smartpacts.shares.enforce-unit 1))
+    (enforce-unit 1))
+
 (expect-failure
     "Returns error with string number"
     "Type error: expected decimal, found string"
-    (smartpacts.shares.enforce-unit "1.0"))
+    (enforce-unit "1.0"))
+
 (expect-failure
     "Returns error with boolean input"
     "Type error: expected decimal, found bool"
-    (smartpacts.shares.enforce-unit true))
+    (enforce-unit true))
+
 (expect-failure
     "Returns error with list input"
     "Type error: expected decimal, found [<a>]"
-    (smartpacts.shares.enforce-unit [1.0]))
+    (enforce-unit [1.0]))
+
 (expect-failure
     "Returns error with object input"
     "Type error: expected decimal, found object:*"
-    (smartpacts.shares.enforce-unit {"amount":1.0}))
+    (enforce-unit {"amount":1.0}))
+
 (expect-failure
     "Returns Tx Failed message with more than 12 decimal digits"
     "Failure: Tx Failed: Amount violates minimum precision: 1.1234567890123"
-    (smartpacts.shares.enforce-unit 1.1234567890123))
+    (enforce-unit 1.1234567890123))
+
 (expect-failure
     "Returns Tx Failed message with more than 12 negative decimal digits"
     "Failure: Tx Failed: Amount violates minimum precision: -1.1234567890123"
-    (smartpacts.shares.enforce-unit -1.1234567890123))    
+    (enforce-unit -1.1234567890123))   
+
+(commit-tx)
+
+(env-data {})
+(env-sigs [])
+
+; validate-account ensures the account name of shares is within SHARES_CHARSET, MINIMUM_ACCOUNT_LENGTH and MAXIMUM_ACCOUNT_LENGTH policies.
+; input must be string.
+; input must be in CHARSET_LATIN1 (ISO-8859-1).
+; input must be 3 or more characters.
+; input must be 256 or less characters.
+; output must boolean.
+
+(begin-tx "validate-account testing")
+  
+(use smartpacts.shares)
+
+(expect-failure
+    "Returns error if non-latin1+ascii characters in string"
+    "charset"
+    (validate-account "alicexπ"))
+  
+(expect-failure
+    "Returns error if empty string"
+    "min length"
+    (validate-account ""))
+
+(expect-failure
+    "Returns error if string not 3 or more characters"
+    "min length"
+    (validate-account "al"))
+
+(expect-failure
+    "Returns error if string not 256 or less characters"
+    "max length"
+    (validate-account
+        "The brown fox jumps over the lazy dog. This is a test sentence to generate 256 characters. \
+        \The quick brown fox jumps over the lazy dog. This is a test sentence to generate 256 characters. \
+        \The quick brown fox jumps over the lazy dog. This is a test sentence to generate 256 characters. \
+        \The quick brown fox jumps over the lazy dog. This is a test sentence to generate 256 characters."))
+
+(expect-failure
+    "Returns error with boolean input"
+    "Type error: expected string, found bool"
+    (validate-account true))
+
+(expect-failure
+    "Returns error with list input"
+    "Type error: expected string, found [<a>]"
+    (validate-account [1.0]))
+
+(expect-failure
+    "Returns error with object input"
+    "Type error: expected string, found object:*"
+    (validate-account {"amount":1.0}))
+
 (commit-tx)
 
 ;(env-data {})
 ;(env-sigs [])
 ;
 ;(begin-tx)
+;(use smartpacts.shares) 
 ;(smartpacts.shares.create-shares-account k.ALICE (describe-keyset "smartpacts.alice-keyset"))
 ;(print (format "create-shares-account 'Alice' gas cost: {}" [(env-gas)]))
 ;(smartpacts.shares.create-shares-account k.BOB (describe-keyset "smartpacts.bob-keyset"))


### PR DESCRIPTION
"Begin Tx 15: validate-account testing"
"Using smartpacts.shares"
"Expect failure: success: Returns error if non-latin1+ascii characters in string"
"Expect failure: success: Returns error if empty string"
"Expect failure: success: Returns error if string not 3 or more characters"
"Expect failure: success: Returns error if string not 256 or less characters"
"Expect failure: success: Returns error with boolean input"
"Expect failure: success: Returns error with list input"
"Expect failure: success: Returns error with object input"
"Commit Tx 15: validate-account testing"